### PR TITLE
feat: ISBN-13 중복 체크 및 에러 메시지 추가

### DIFF
--- a/Backend/constants/index.ts
+++ b/Backend/constants/index.ts
@@ -8,6 +8,7 @@ export const QUERY_ERROR_MESSAGE = {
     CREATE_BOOK: "도서 생성 쿼리 오류:",
     EDIT_BOOK: "도서 수정 쿼리 오류:",
     DELETE_BOOK: "도서 삭제 오류:",
+    ISBN_DUPLICATE: "이미 존재하는 ISBN13 입니다."
 };
 
 export const SUCCESS_MESSAGE = {

--- a/Frontend/src/constants/HTTPErrorMessage.ts
+++ b/Frontend/src/constants/HTTPErrorMessage.ts
@@ -7,6 +7,10 @@ export const HTTP_ERROR_MESSAGE = {
         HEADING: "404",
         BODY: "요청하신 페이지를 찾을 수 없습니다.",
     },
+    409: {
+        HEADING: "이미 존재하는 ISBN-13입니다.",
+        BODY: "동일한 ISBN-13을 가진 도서가 이미 존재합니다. 다른 ISBN-13을 입력해주세요.",
+    },
     500: {
         HEADING: "서버 오류가 발생했습니다",
         BODY: "잠시 후 다시 요청해주세요.",


### PR DESCRIPTION
- 도서 생성 및 수정 시 ISBN-13 중복 여부를 검사하여 중복된 경우 409 Conflict 상태 코드 반환
- 백엔드: `QUERY_ERROR_MESSAGE`에 ISBN 중복 관련 메시지 추가 (`ISBN_DUPLICATE`)
- 백엔드: `SUCCESS_MESSAGE`를 적용하여 생성, 수정, 삭제 시 명확한 응답 메시지 반환
- 프론트엔드: `HTTP_ERROR_MESSAGE`에 409 상태 코드에 대한 에러 메시지 추가
- 클라이언트가 ISBN 중복 오류를 직관적으로 인식할 수 있도록 개선